### PR TITLE
:bug: Fix command name, add shebang to app.js

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const program = require('commander'),
   version = require('./package.json').version,
   FromXml = require('./lib/FromXml'),

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "bin": {
-    "xpathgenerator": "app.js"
+    "xpath-generator": "app.js"
   },
   "dependencies": {
     "bluebird": "^3.4.6",


### PR DESCRIPTION
I corrected the command's name (added `-`).

I added the shebang to `app.js`, so that node is found when running it.